### PR TITLE
Fix spelling mistakes in the readme

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,16 +1,16 @@
 # Java Reflection Event System
 
-This library allow you to write your application under an event driven architecture in a easy and beautiful way.
+This library allows you to write your application under an event driven architecture in an easy and beautiful way.
 
-# How does it works?
+# How does it work?
 
 ### Code is controlled by event handlers, not by manual function calls.
 
-These event handlers can be plugged or unplugged at any time without having to change nothing from the original code.
+These event handlers can be plugged or unplugged at any time without having to change from the original code.
 
 ![Event execution flow](/documentation/images/event-call-execution-animation.gif)
 
-# More inforation
+# More information
 
 You can read the projects wikis to understand how to use this library.
 https://github.com/xXNurioXx/ReflectedEventHandler/wiki


### PR DESCRIPTION
Readme has a few spelling mistakes, just a simple PR to fix this.

In addition, the documentation is really needs an update. (Specifically, the event manager and the example given to instantiate that is old and no longer accurate). It also looks like the repository link provided in the documentation doesn't exist anymore.

As far as I can see, public github doesn't allow you to create a pull request on wiki articles, otherwise I'd fix those here too.